### PR TITLE
jitter in section attributes dialog

### DIFF
--- a/BackgroundComposer.css
+++ b/BackgroundComposer.css
@@ -21,7 +21,7 @@
 	right: 0;
 	bottom: 0;
 	left: 0;
-	z-index: 10;
+	z-index: 20;
 	text-align: right;
 	cursor: pointer;
 	padding: 4px 8px;


### PR DESCRIPTION
To avoid jitter in Opera, z-index should be 0 or greater than 10, but not in the rang from 1 to 10. 
I do not know why.
Actually, it works fine without z-index at all.